### PR TITLE
Fix GET operation response, unmarshal correct KeyValue type

### DIFF
--- a/base_objects.go
+++ b/base_objects.go
@@ -125,13 +125,11 @@ type AttestationCredentialValue struct {
 //
 // The Key Block SHALL contain a Key Wrapping Data structure if the key in the Key Value field is
 // wrapped (i.e., encrypted, or MACed/signed, or both).
-//
-// TODO: Unmarshaler impl which unmarshals correct KeyValue type.
+
 type KeyBlock struct {
-	KeyFormatType      kmip14.KeyFormatType
-	KeyCompressionType kmip14.KeyCompressionType `ttlv:",omitempty"`
-	// KeyValue should be either []byte or KeyValue
-	KeyValue               interface{}                   `ttlv:",omitempty"` // should be either a []byte or KeyValue
+	KeyFormatType          kmip14.KeyFormatType
+	KeyCompressionType     kmip14.KeyCompressionType     `ttlv:",omitempty"`
+	KeyValue               KeyValue                      `ttlv:",omitempty"`
 	CryptographicAlgorithm kmip14.CryptographicAlgorithm `ttlv:",omitempty"`
 	CryptographicLength    int                           `ttlv:",omitempty"`
 	KeyWrappingData        *KeyWrappingData

--- a/base_objects.go
+++ b/base_objects.go
@@ -129,7 +129,7 @@ type AttestationCredentialValue struct {
 type KeyBlock struct {
 	KeyFormatType          kmip14.KeyFormatType
 	KeyCompressionType     kmip14.KeyCompressionType     `ttlv:",omitempty"`
-	KeyValue               *KeyValue                      `ttlv:",omitempty"`
+	KeyValue               *KeyValue                     `ttlv:",omitempty"`
 	CryptographicAlgorithm kmip14.CryptographicAlgorithm `ttlv:",omitempty"`
 	CryptographicLength    int                           `ttlv:",omitempty"`
 	KeyWrappingData        *KeyWrappingData

--- a/base_objects.go
+++ b/base_objects.go
@@ -129,7 +129,7 @@ type AttestationCredentialValue struct {
 type KeyBlock struct {
 	KeyFormatType          kmip14.KeyFormatType
 	KeyCompressionType     kmip14.KeyCompressionType     `ttlv:",omitempty"`
-	KeyValue               KeyValue                      `ttlv:",omitempty"`
+	KeyValue               *KeyValue                      `ttlv:",omitempty"`
 	CryptographicAlgorithm kmip14.CryptographicAlgorithm `ttlv:",omitempty"`
 	CryptographicLength    int                           `ttlv:",omitempty"`
 	KeyWrappingData        *KeyWrappingData

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/ansel1/merry v1.6.2
+	github.com/baum/kmip-go v0.0.0-20220714190649-7b37ecf92eb2
 	github.com/gemalto/flume v0.13.0
 	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/ansel1/merry/v2 v2.0.1 h1:WeiKZdslHPAPFYxTtgX7clC2Vh75NCoWs5OjCZbIA0A
 github.com/ansel1/merry/v2 v2.0.1/go.mod h1:dD5OhpiPrVkvgseRYd+xgYlx7s6ytU3v9BTTJlDA7FM=
 github.com/ansel1/vespucci/v4 v4.1.1/go.mod h1:zzdrO4IgBfgcGMbGTk/qNGL8JPslmW3nPpcBHKReFYY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/baum/kmip-go v0.0.0-20220714190649-7b37ecf92eb2 h1:36jcWIS7S1M2yZ/GsXqqIfbRvO+1dg4v+9VhGrwsr84=
+github.com/baum/kmip-go v0.0.0-20220714190649-7b37ecf92eb2/go.mod h1:5WlKRqL5dfI68V56W+4ZmlPSL+TSfqQrKJYI8CSJz+E=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/op_get.go
+++ b/op_get.go
@@ -16,7 +16,14 @@ type GetRequestPayload struct {
 type GetResponsePayload struct {
 	ObjectType       kmip14.ObjectType
 	UniqueIdentifier string
-	Key              string
+	Certificate      *Certificate
+	SymmetricKey     *SymmetricKey
+	PrivateKey       *PrivateKey
+	PublicKey        *PublicKey
+	SplitKey         *SplitKey
+	Template         *Template
+	SecretData       *SecretData
+	OpaqueObject     *OpaqueObject
 }
 
 type GetHandler struct {


### PR DESCRIPTION
Fix GET operation response, unmarshal correct KeyValue type

See sample test code:

* https://github.com/baum/kmip-go/blob/master/ciphertrust_test.go